### PR TITLE
Better reporting for gecko.toml parsing

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -119,7 +119,7 @@ pub fn build_package<'a>(
     // TODO: File names need to conform to identifier rules.
     let source_file_name = path.file_stem().unwrap().to_string_lossy().to_string();
 
-    progress_bar.set_message(format!("{}", source_file_name));
+    progress_bar.set_message(source_file_name.clone());
 
     // TODO: Clear progress bar on error.
     let source_file_contents = package::fetch_source_file_contents(&path)?;
@@ -159,7 +159,7 @@ pub fn build_package<'a>(
     progress_bar.inc(1);
   }
 
-  progress_bar.finish_and_clear();
+  progress_bar.finish();
 
   // TODO: In the future, use the appropriate time unit (min, sec, etc.) instead of just `s`.
   log::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,6 @@ async fn main() -> Result<(), i32> {
     .version(clap::crate_version!())
     .author(clap::crate_authors!())
     .about("Package manager & command-line utility for the gecko programming language")
-    // TODO: Make this a positional under the `build` subcommand.
-    .arg(
-      clap::Arg::with_name(ARG_FILE)
-        .help("The file to process")
-        .index(1),
-    )
     .subcommand(
       clap::SubCommand::with_name(ARG_BUILD)
         .about("Build the project in the current directory")
@@ -48,6 +42,11 @@ async fn main() -> Result<(), i32> {
             .short("p")
             .long(ARG_BUILD_PRINT_OUTPUT)
             .help("Print the resulting LLVM IR instead of producing an output file"),
+        )
+        .arg(
+          clap::Arg::with_name(ARG_FILE)
+            .help("The file to process")
+            .index(1),
         )
     )
     .subcommand(


### PR DESCRIPTION
Previously no errors where reported when grip failed to create a new package or when failing to parse gecko.toml
This patch provides error messages in these cases.